### PR TITLE
Release 1.1.7

### DIFF
--- a/src/helpers/excerpt.js
+++ b/src/helpers/excerpt.js
@@ -3,11 +3,14 @@
  *
  * @api public
  *
- * @param {string} str    The string to format
- * @param {number} length The number of characters to limit to
+ * @param {string} text                      The string to format
+ * @param {Object} options                   The helper option set
+ * @param {number} [options.hash.length=100] The character length to limit to
  *
  * @return {string}
  */
-module.exports = function (str, length) {
-    return str.slice(0, length > 0 ? length : 100).replace(/\s\w+$/, '…');
+module.exports = function (text, { hash: { length = 100 }}) {
+    return text.length > length
+        ? text.slice(0, length).replace(/\s\w+$/, '…')
+        : text;
 };

--- a/src/helpers/excerpt.js
+++ b/src/helpers/excerpt.js
@@ -3,10 +3,10 @@
  *
  * @api public
  *
- * @param {String} str    The string to format
- * @param {Number} length The number of characters to limit to
+ * @param {string} str    The string to format
+ * @param {number} length The number of characters to limit to
  *
- * @return {String}
+ * @return {string}
  */
 module.exports = function (str, length) {
     return str.slice(0, length > 0 ? length : 100).replace(/\s\w+$/, '…');

--- a/src/helpers/take.js
+++ b/src/helpers/take.js
@@ -4,9 +4,9 @@
  * @api public
  *
  * @param {Array}  array The array
- * @param {Number} limit The number of items to limit to
+ * @param {number} limit The number of items to limit to
  *
- * @return {String}
+ * @return {string}
  */
 module.exports = function (array, limit) {
     return array.slice(0, limit);


### PR DESCRIPTION
Update `excerpt` Handlebars helper to fix behaviour when applying to strings smaller than the shortening length. This will correctly format today's iA Writer Medium post.